### PR TITLE
Peer Review #2

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -100,7 +100,7 @@ keytool -genkey \
     -alias selfsigned ^
     -keystore key.p12 ^
     -storetype PKCS12 ^
-    -storepass [truststore-password] ^
+    -storepass [keystore-password] ^
     -validity 360 ^
     -keysize 2048
 ```
@@ -158,7 +158,7 @@ keytool \
     -alias github \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit \
+    -storepass [truststore-password] \
     -noprompt
 keytool \
     -import -trustcacerts \
@@ -166,7 +166,7 @@ keytool \
     -alias github_api \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit \
+    -storepass [truststore-password] \
     -noprompt
 ```
 --
@@ -180,7 +180,7 @@ keytool \
     -alias github ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit ^
+    -storepass [truststore-password] ^
     -noprompt
 %JAVA_HOME%\bin\keytool ^
     -import -trustcacerts ^
@@ -188,7 +188,7 @@ keytool \
     -alias github_api ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit ^
+    -storepass [truststore-password] ^
     -noprompt
 ```
 --
@@ -243,7 +243,7 @@ keytool \
 ```
 --
 
-Next, run the following command to add the downloaded certificates into a keystore named `slts.p12`, which will be your application's truststore. Replace `[truststore-password]` with a password for your truststore.
+Next, run the following command to add the downloaded certificates into a keystore named `slts.p12`, which will be your application's truststore. Replace `[truststore-password]` with the password you used in the previous section for your truststore.
 You will need this password in later sections in the guide.
 
 include::{common-includes}/os-tabs.adoc[]
@@ -257,7 +257,7 @@ keytool \
     -alias amazon \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit \
+    -storepass [truststore-password] \
     -noprompt
 keytool \
     -import -trustcacerts \
@@ -265,7 +265,7 @@ keytool \
     -alias amazon_api \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit \
+    -storepass [truststore-password] \
     -noprompt
 ```
 --
@@ -279,7 +279,7 @@ keytool \
     -alias amazon ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit ^
+    -storepass [truststore-password] ^
     -nporompt
 %JAVA_HOME%\bin\keytool ^
     -import -trustcacerts ^
@@ -287,7 +287,7 @@ keytool \
     -alias amazon_api ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit ^
+    -storepass [truststore-password] ^
     -noprompt
 ```
 --
@@ -342,7 +342,7 @@ keytool \
 ```
 --
 
-Next, run the following command to add the downloaded certificates into a keystore named `slts.p12`, which will be your application's truststore. Replace `[truststore-password]` with a password for your truststore.
+Next, run the following command to add the downloaded certificates into a keystore named `slts.p12`, which will be your application's truststore. Replace `[truststore-password]` with the password you used in the previous section for your truststore.
 You will need this password in later sections in the guide.
 
 include::{common-includes}/os-tabs.adoc[]
@@ -356,7 +356,7 @@ keytool \
     -alias google \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit \
+    -storepass [truststore-password] \
     -noprompt
 keytool \
     -import -trustcacerts \
@@ -364,7 +364,7 @@ keytool \
     -alias googleapis \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit \
+    -storepass [truststore-password] \
     -noprompt
 ```
 
@@ -379,7 +379,7 @@ keytool \
     -alias google ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit ^
+    -storepass [truststore-password] ^
     -noprompt
  %JAVA_HOME%\bin\keytool ^
     -import -trustcacerts ^
@@ -387,7 +387,7 @@ keytool \
     -alias googleapis ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit ^
+    -storepass [truststore-password] ^
     -noprompt
 ```
 --

--- a/README.adoc
+++ b/README.adoc
@@ -51,9 +51,8 @@ which only require that you provide the credentials obtained by registering for 
 By the end of this guide, you will be able to secure the HelloService service using:
 
 1. A pre-configured social media login (GitHub)
-1. A custom OAuth2 login provider configuration (Amazon)
-1. A custom OIDC login provider configuration (Google)
-
+2. A custom OAuth2 login provider configuration (Amazon)
+3. A custom OIDC login provider configuration (Google)
 
 // =================================================================================================
 // Getting Started
@@ -93,6 +92,8 @@ keytool -genkey \
 ```
 --
 [.tab_content.windows_section]
+--
+[role='command']
 ```
 %JAVA_HOME%\bin\keytool -genkey ^
     -keyalg RSA ^
@@ -366,6 +367,7 @@ keytool \
     -storepass changeit \
     -noprompt
 ```
+
 --
 [.tab_content.windows_section]
 --
@@ -421,21 +423,21 @@ The [hotspot=helloService]`HelloService` class is the JAX-RS service that you wi
 ----
 #Replace the `HelloService` class.#
 `src/main/java/io/openliberty/guides/sociallogin/HelloService.java`
----- 
+----
 
 The following new imports are required for the [hotspot=helloService]`HelloService` class:
 
 - [hotspot=rolesAllowedImport]`javax.annotation.security.RolesAllowed`
-- [hotspot=httpServletRequestImport]`javax.servlet.http.HttpServletRequest`
+- [hotspot=securityContextImport]`javax.ws.rs.core.SecurityContext`
 - [hotspot=contextImport]`javax.ws.rs.core.Context`
 
 The [hotspot=rolesAllowed]`@RolesAllowed({"users"})` annotation restricts access to the service to users who are
 in the `users` role.
 
 The `return "Hello, friend!";` is replaced to output user information.
-The [hotspot=httpServletRequestContext]`HttpServletRequest` context, which is injected using the
-[hotspot=contextAnnotation]`@Context` annotation, allows you to get information about the logged-in user
-using [hotspot=userPrincipal]`request.getUserPrincipal()`.
+The [hotspot=securityContext]`SecurityContext` context, which is injected using the
+[hotspot=securityContext]`@Context` annotation, allows you to get information about the logged-in user
+using [hotspot=userPrincipal]`securitContext.getUserPrincipal()`.
 
 HelloService.java 
 [source, Java, linenums, role='code_column hide_tags=copyright'] 
@@ -446,16 +448,16 @@ include::finish/src/main/java/io/openliberty/guides/sociallogin/HelloService.jav
 == Configuring the security and social media login
 
 [role="code_command hotspot file=0", subs="quotes"] 
----- 
+----
 #Replace the server configuration file.#
 `src/main/liberty/config/server.xml`
 ----
 
 server.xml 
 [source, xml, linenums, role='code_column']
----- 
+----
 include::finish/src/main/liberty/config/server.xml[]
----- 
+----
 
 The explanations for these changes are in the following sections.
 
@@ -465,12 +467,6 @@ The [hotspot=applicationBnd]`<application-bnd />` configuration element under th
 [hotspot=webApplication]`<webApplication />` configuration element creates a new security role [hotspot=users]`users`,
 which all authenticated users belong to.
 Adding this allows users that are authenticated using social media login to access your `HelloService` service.
-
-server.xml
-[source, xml, linenums, role='code_column']
-----
-include::finish/src/main/liberty/config/server.xml[]
----- 
 
 === Adding required features
 
@@ -493,26 +489,56 @@ so the location of these keystores is `${server.output.dir}/resources/security`.
 
 The [hotspot=keystore]`defaultKeyStore` configuration element, whose location is `${server.output.dir}/resources/security/key.p12`,
 will be used to provide SSL certificates when initiating HTTPS connections for social media login.
-Provide the password that you used when creating the keystore.
+
+[role="code_command hotspot=sections", subs="quotes"] 
+----
+#Update the `server.xml` file.#
+`src/liberty/config/server.xml`
+----
+[role="edit_command_text"]
+Replace [hotspot=29]`[keystore-password]` with the password that you used when creating the keystore in the previous sections.
 
 The [hotspot=truststore]`socialLoginKeyStore` configuration element, whose location is `${server.output.dir}/resources/security/slts.p12`,
 will be used to store trusted certificates when initiating HTTPS connections to social media APIs for authorization and authentication.
-Provide the password that you usd when creating the truststore.
+
+[role="code_command hotspot=sections", subs="quotes"] 
+----
+#Update the `server.xml` file.#
+`src/liberty/config/server.xml`
+----
+[role="edit_command_text"]
+Replace [hotspot=22]`[truststore-password]` with the password that you used when creating the truststore in the previous sections.
 
 The [hotspot=sslConfig]`authServiceSslRef` configuration element, which references [hotspot=keystore]`defaultKeyStore` as the keystore
 and [hotspot=truststore]`socialLoginKeyStore` as the truststore, will be provided to social media login configurations.
 
 === Adding GitHub login configuration
 
-The [hotspot=githubLogin]`<githubLogin />` configuration element will configure GitHub login.
+[role="code_command hotspot=sections", subs="quotes"] 
+----
+#Update the `server.xml` file.#
+`src/liberty/config/server.xml`
+----
+[role="edit_command_text"]
 Replace the values of the [hotspot=43]`clientId` and [hotspot=44]`clientSecret` with the credentials you created for your GitHub application
-in the prerequisites section. The [hotspot=45]`sslRef` attribute is set to the [hotspot=sslConfig]`authServiceSslRef` configuration from the previous section.
+in the prerequisites section.
+
+The [hotspot=githubLogin]`<githubLogin />` configuration element will configure GitHub login.
+The [hotspot=45]`sslRef` attribute is set to the [hotspot=sslConfig]`authServiceSslRef` configuration from the previous section.
 
 === Adding Amazon login configuration
 
-The [hotspot=amazonLogin]`amazonLogin` configuration uses a custom [hotspot=amazonLogin]`<oauth2Login />` configuration element.
+[role="code_command hotspot=sections", subs="quotes"] 
+----
+#Update the `server.xml` file.#
+`src/liberty/config/server.xml`
+----
+[role="edit_command_text"]
 Replace the values of [hotspot=52]`clientId` and [hotspot=53]`clientSecret` with the credentials you created for your Amazon application
-in the prerequisites section. The [hotspot=55]`sslRef` attribute is set to the [hotspot=sslConfig]`authServiceSslRef` configuration from the previous section.
+in the prerequisites section.
+
+The [hotspot=amazonLogin]`amazonLogin` configuration uses a custom [hotspot=amazonLogin]`<oauth2Login />` configuration element.
+The [hotspot=55]`sslRef` attribute is set to the [hotspot=sslConfig]`authServiceSslRef` configuration from the previous section.
 
 Further documentation on the [hotspot=amazonLogin]`attributes` can be found on the https://openliberty.io/docs/ref/config/oauth2Login.html[Open Liberty config reference on oauth2Login^].
 The values for these [hotspot=amazonLogin]`attributes` can be found in the https://developer.amazon.com/docs/login-with-amazon/minitoc-lwa-overview.html[Login With Amazon API documentation^].
@@ -521,9 +547,17 @@ Make sure that the [hotspot=50]`id` of your [hotspot=amazonLogin]`<oauth2Login /
 
 === Adding Google login configuration
 
-The [hotspot=googleOIDCLogin]`googleOIDCLogin` configuration uses a custom [hotspot=googleOIDCLogin]`<oidcLogin />` configuration element.
+[role="code_command hotspot=sections", subs="quotes"] 
+----
+#Update the `server.xml` file.#
+`src/liberty/config/server.xml`
+----
+[role="edit_command_text"]
 Repalce the values of [hotspot=70]`clientId` and [hotspot=71]`clientSecret` with the credentials you created for your Google application
-in the prerequisites section. The [hotspot=72]`sslRef` attribute is set to the [hotspot=sslConfig]`authServiceSslRef` configuration from the previous section.
+in the prerequisites section.
+
+The [hotspot=googleOIDCLogin]`googleOIDCLogin` configuration uses a custom [hotspot=googleOIDCLogin]`<oidcLogin />` configuration element.
+The [hotspot=72]`sslRef` attribute is set to the [hotspot=sslConfig]`authServiceSslRef` configuration from the previous section.
 
 Further documentation on the [hotspot=googleOIDCLogin]`attributes` can be found on the https://openliberty.io/docs/ref/config/oidcLogin.html[Open Liberty config reference on oidcLogin^].
 The values of these [hotspot=googleOIDCLogin]`attributes` can be found in the https://developers.google.com/identity/protocols/OpenIDConnect[Google API documentation^].
@@ -545,10 +579,9 @@ for authentication. When you select a login choice, you will be redirected to th
 Try logging in using your social media accounts. After authenticating, you will be redirected back to https://localhost:9080/api/hello and the response will look like this:
 
 [source,role="no_copy"]
-----
+---
 Hello, <<your username>>
-WSPrincipal:<<your username>>
-----
+---
 
 == Testing the service
 

--- a/README.adoc
+++ b/README.adoc
@@ -14,11 +14,11 @@
 :page-essential-order: 1
 :page-description: Learn how to secure a RESTful web service with the Open Liberty Social Media Login feature.
 :guide-author: Open Liberty
-:page-tags: ['Social Media Login', 'Java EE', 'Jakarta EE', 'Security']
+:page-tags: ['Java EE', 'Jakarta EE', 'Security']
 :page-related-guides: ['microprofile-jwt', 'security-intro', 'rest-client-java', 'rest-client-angularjs']
 :page-permalink: /guides/{projectid}
 :page-seo-title: Securing a RESTful web service with Social Media Login
-:page-seo-description: A tutorial on how to secure a RESTful web service in Open Liberty using the SocialLogin feature
+:page-seo-description: A tutorial on how to secure a RESTful web service in Open Liberty using the Social Media Login feature
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
 = Securing a RESTful web service with Social Media Login
 
@@ -249,7 +249,7 @@ In order to obtain OAuth 2.0 credentials for GitHub,
 . Log into https://github.com/[GitHub^].
 . Navigate to https://github.com/settings/developers[OAuth Apps^] and click on "New OAuth App".
 . Enter an application name.
-. Set "Homepage URL" to `\https://localhost:9444/`.
+. Set "Homepage URL" to `\https://localhost:9443/`.
 . Set "Authorization callback URL" to `\https://localhost:9443/ibm/api/social-login/redirect/githubLogin`.
 . Click on "Register application".
 
@@ -504,7 +504,7 @@ The explanations for these changes are in the following sections.
 The [hotspot=applicationBnd]`<application-bnd />` configuration element under the
 [hotspot=webApplication]`<webApplication />` configuration element creates a new security role [hotspot=users]`users`,
 which all authenticated users belong to.
-Adding this allows users that are authenticated using social media login to access your [hotspot=helloService]`HelloService` service.
+Adding this allows users that are authenticated using social media login to access your `HelloService` service.
 
 server.xml
 [source, xml, linenums, role='code_column']
@@ -515,7 +515,7 @@ include::finish/src/main/liberty/config/server.xml[]
 === Adding required features
 
 To enable https://openliberty.io/docs/ref/feature/#socialLogin-1.0.html[Social Media Login feature^] and other required features, add new [hotspot=newFeatures]`<feature />` elements to the [hotspot=featureManager]`<featureManager />` in
-[hotspot file=0]`src/main/liberty/config/server.xml`
+`server.xml`
 
 There are some prerequisite configurations that social media login configuration elements need:
 
@@ -528,7 +528,7 @@ corresponds to the keystore created in the prerequisites section
 
 In the first section, you created two keystores, `slts.p12` and `key.p12`.
 Now you will configure your application to use these keystores.
-Files in the `src/liberty` folder are copied into the location specified by `${server.output.dir}`,
+Files in the `src/main/liberty` folder are copied into the location specified by `${server.output.dir}`,
 so the location of these keystores is `${server.output.dir}/resources/security`.
 
 The [hotspot=keystore]`defaultKeyStore` configuration element, whose location is `${server.output.dir}/resources/security/key.p12`,

--- a/README.adoc
+++ b/README.adoc
@@ -43,12 +43,17 @@ Instead of securing the `HelloService` service by implementing your own authenti
 you can allow users to authenticate the service using social media accounts.
 This will allow you to provide a secure authentication method for your users without having to explicitly implement it.
 
-Open Liberty provides a https://openliberty.io/docs/ref/feature/#socialLogin-1.0.html[Social Media Login feature^]
-that provides configuration elements that allow you to use Facebook, Google, GitHub, or LinkedIn for authentication,
-or to configure a custom OAuth2 or OpenID Connect provider like Amazon.
+Open Liberty provides a https://openliberty.io/docs/ref/feature/#socialLogin-1.0.html[Social Media Login Feature^]
+that provides configuration elements that allow you to configure an OAuth2 or OpenID Connect provider.
+The feature also provides preconfigured elements for common social media platforms like Facebook, Google, GitHub, LinkedIn and Twitter,
+which only require that you provide the credentials obtained by registering for an application on that platform.
 
-By the end of this guide, you will be able to secure the HelloService service using three
-social media developer platforms: GitHub, Amazon and Google.
+By the end of this guide, you will be able to secure the HelloService service using:
+
+1. A pre-configured social media login (GitHub)
+1. A custom OAuth2 login provider configuration (Amazon)
+1. A custom OIDC login provider configuration (Google)
+
 
 // =================================================================================================
 // Getting Started
@@ -67,94 +72,36 @@ First, navigate to the `start/src/main/liberty/config/resources/security` direct
 
 === Generating a self signed certificate
 Your application requires a TLS server certificate and corresponding private key to securely communicate using HTTPS. In this section, you will
-generate a self signed certificate and add it to your application's keystore.
+generate a self signed certificate and add it to your `key.p12`, which you will be your application's keystore.
 
-To generate a server certificate and private key for your service to use for HTTPS connections, run the following command:
+To create a self-signed certificate and add it to `key.p12` using the Java `keytool`,
+run the following command. Replace `[keystore-password]` with a password for your keystore.
+You will need this password in later sections in the guide.
 include::{common-includes}/os-tabs.adoc[]
 [.tab_content.linux_section.mac_section]
 --
 [role='command']
 ```
-openssl req \
-    -x509 \
-    -newkey rsa:4096 \
-    -keyout key.pem \
-    -out cert.pem \
-    -days 365 \
-    -subj "/C=CA/CN=localhost"
-```
-
-When prompted for `PEM pass phrase`, enter a pass phrase for `key.pem`.
-
---
-[.tab_content.windows_section]
---
-[role='command']
-```
-powershell New-SelfSignedCertificate ^
-    -Subject \"C=CA,CN=localhost\" ^
-    -KeyAlgorithm RSA ^
-    -KeyLength 4096 ^
-    -CertStoreLocation "Cert:\CurrentUser\My" ^
-    -FriendlyName "SocialLoginServer"
-```
---
-
-Before the certificate and private key can be imported into the keystore for your service, it needs to be converted into one `PKCS12` bundle.
-
-include::{common-includes}/os-tabs.adoc[]
-[.tab_content.linux_section.mac_section]
---
-Combine your key and certificate by running the following command.
-When prompted for `Export Password`, set the password for the exported certificate bundle, `certificate.p12`.
-[role='command']
-```
-openssl pkcs12 \
-    -inkey key.pem \
-    -in cert.pem \
-    -export -out certificate.p12
+keytool -genkey \
+    -keyalg RSA \
+    -alias selfsigned \
+    -keystore key.p12 \
+    -storetype PKCS12
+    -storepass [keystore-password] \
+    -validity 360 \
+    -keysize 2048
 ```
 --
 [.tab_content.windows_section]
---
-Export your newly created certificate by:
-
-1. Search for "Manage user certificates" in the Start menu.
-2. Epand "Personal".
-3. Click on "Certificates".
-4. Right-click the certificate entry with friendly name "SocialLoginServer".
-5. Hover over "All tasks" in the dropdown menu to expand another dropdown menu.
-6. Click "Export...". Then click "Next".
-7. Select the radio button "Yes, export the private key".
-8. Continue through the rest of the prompts in the Export wizard.
-9. When prompted for a file name, click "Browse" to save the file as `certificate.pfx` in the current working directory.
---
-
-The keystore to be used by social media login will be configured to be `key.p12` whose password is `changeit`.
-To import your certificate bundle into this keystore, run the following command:
-include::{common-includes}/os-tabs.adoc[]
-[.tab_content.linux_section.mac_section]
---
-[role='command']
 ```
-keytool \
-    -importkeystore \
-    -srckeystore certificate.p12 \
-    -srcstoretype PKCS12 \
-    -destkeystore key.p12 \
-    -deststoretype PKCS12
-```
---
-[.tab_content.windows_section]
---
-[role='command']
-```
-%JAVA_HOME%\bin\keytool ^
-    -importkeystore ^
-    -srckeystore certificate.pfx ^
-    -srcstoretype PKCS12 ^
-    -destkeystore key.p12 ^
-    -deststoretype PKCS12
+%JAVA_HOME%\bin\keytool -genkey ^
+    -keyalg RSA ^
+    -alias selfsigned ^
+    -keystore key.p12 ^
+    -storetype PKCS12 ^
+    -storepass [truststore-password] ^
+    -validity 360 ^
+    -keysize 2048
 ```
 --
 
@@ -196,7 +143,8 @@ keytool \
 ```
 --
 
-Next, run the following command to add the downloaded certificates into a keystore named `slts.p12`. You will configure your application's truststore to be this keystore later in this guide.
+Next, run the following command to add the downloaded certificates into a keystore named `slts.p12`, which will be your application's truststore. Replace `[truststore-password]` with a password for your truststore.
+You will need this password in later sections in the guide.
 
 include::{common-includes}/os-tabs.adoc[]
 [.tab_content.linux_section.mac_section]
@@ -294,7 +242,8 @@ keytool \
 ```
 --
 
-Next, run the following command to add the downloaded certificates into a keystore named `slts.p12`. You will configure your application's truststore to be this keystore later in this guide.
+Next, run the following command to add the downloaded certificates into a keystore named `slts.p12`, which will be your application's truststore. Replace `[truststore-password]` with a password for your truststore.
+You will need this password in later sections in the guide.
 
 include::{common-includes}/os-tabs.adoc[]
 [.tab_content.linux_section.mac_section]
@@ -342,7 +291,7 @@ keytool \
 ```
 --
 
-The last prerequisite step for GitHub is obtaining client ID and client secret for access to the GitHub developer API.
+The last prerequisite step for Amazon is obtaining client ID and client secret for access to the Login with Amazon API.
 
 In order to obtain OAuth 2.0 credentials for GitHub,
 
@@ -392,7 +341,8 @@ keytool \
 ```
 --
 
-Next, run the following command to add the downloaded certificates into a keystore named `slts.p12`. You will configure your application's truststore to be this keystore later in this guide.
+Next, run the following command to add the downloaded certificates into a keystore named `slts.p12`, which will be your application's truststore. Replace `[truststore-password]` with a password for your truststore.
+You will need this password in later sections in the guide.
 
 include::{common-includes}/os-tabs.adoc[]
 [.tab_content.linux_section.mac_section]
@@ -468,7 +418,7 @@ include::{common-includes}/devmode-start.adoc[]
 The [hotspot=helloService]`HelloService` class is the JAX-RS service that you will be securing.
 
 [role="code_command hotspot file=0", subs="quotes"] 
----- 
+----
 #Replace the `HelloService` class.#
 `src/main/java/io/openliberty/guides/sociallogin/HelloService.java`
 ---- 

--- a/README.adoc
+++ b/README.adoc
@@ -71,7 +71,7 @@ First, navigate to the `start/src/main/liberty/config/resources/security` direct
 
 === Generating a self signed certificate
 Your application requires a TLS server certificate and corresponding private key to securely communicate using HTTPS. In this section, you will
-generate a self signed certificate and add it to your `key.p12`, which you will be your application's keystore.
+generate a self signed certificate and add it to your `key.p12`, which will be your application's keystore.
 
 To create a self-signed certificate and add it to `key.p12` using the Java `keytool`,
 run the following command. Replace `[keystore-password]` with a password for your keystore.
@@ -413,7 +413,7 @@ In order to obtain OAuth 2.0 credentials for Google,
 . Select "OAuth client ID" from the different options.
 . Set the application type to "Web application".
 . Enter the name of your OAuth 2.0 Client ID. This is different from your app name and will not be shown to end users. 
-. Add `\https://localhost:9443/ibm/api/social-login/redirect/googleOIDCLogin` to "Authorized redirect URIs", hit "Enter" and then click "Create".
+. Add `\https://localhost:9443/ibm/api/social-login/redirect/googleOIDCLogin` to "Authorized redirect URIs", hit "Enter" to save the URI and then click "Create".
 
 == Securing HelloService
 
@@ -501,7 +501,7 @@ will be used to provide SSL certificates when initiating HTTPS connections for s
 `src/liberty/config/server.xml`
 ----
 [role="edit_command_text"]
-Replace [hotspot=29]`[keystore-password]` with the password that you used when creating the keystore in the previous sections.
+Replace [hotspot=22]`[keystore-password]` with the password that you used when creating the keystore in the previous sections.
 
 The [hotspot=truststore]`socialLoginKeyStore` configuration element, whose location is `${server.output.dir}/resources/security/slts.p12`,
 will be used to store trusted certificates when initiating HTTPS connections to social media APIs for authorization and authentication.
@@ -512,7 +512,7 @@ will be used to store trusted certificates when initiating HTTPS connections to 
 `src/liberty/config/server.xml`
 ----
 [role="edit_command_text"]
-Replace [hotspot=22]`[truststore-password]` with the password that you used when creating the truststore in the previous sections.
+Replace [hotspot=29]`[truststore-password]` with the password that you used when creating the truststore in the previous sections.
 
 The [hotspot=sslConfig]`authServiceSslRef` configuration element, which references [hotspot=keystore]`defaultKeyStore` as the keystore
 and [hotspot=truststore]`socialLoginKeyStore` as the truststore, will be provided to social media login configurations.

--- a/README.adoc
+++ b/README.adoc
@@ -206,7 +206,7 @@ In order to obtain OAuth 2.0 credentials for GitHub,
 
 === Setting up for Amazon
 
-For your application to communicate securely with GitHub using HTTPS, the TLS server public key certificates for the following domains need to be added to your application's truststore:
+For your application to communicate securely with Amazon using HTTPS, the TLS server public key certificates for the following domains need to be added to your application's truststore:
 
 - `www.amazon.com` (saved as `amazon.pem`)
 - `api.amazon.com` (saved as `amazon_api.pem`)
@@ -294,7 +294,7 @@ keytool \
 
 The last prerequisite step for Amazon is obtaining client ID and client secret for access to the Login with Amazon API.
 
-In order to obtain OAuth 2.0 credentials for GitHub,
+In order to obtain OAuth 2.0 credentials for Amazon,
 
 . Navigate to https://login.amazon.com/[Login with Amazon^].
 . Hover over "Sign-in" and click on "Developer Portal".
@@ -413,7 +413,7 @@ In order to obtain OAuth 2.0 credentials for Google,
 . Select "OAuth client ID" from the different options.
 . Set the application type to "Web application".
 . Enter the name of your OAuth 2.0 Client ID. This is different from your app name and will not be shown to end users. 
-. Add `\https://localhost:9443/ibm/api/social-login/redirect/googleOIDCLogin` to "Authorized redirect URIs", then click "Create".
+. Add `\https://localhost:9443/ibm/api/social-login/redirect/googleOIDCLogin` to "Authorized redirect URIs", hit "Enter" and then click "Create".
 
 == Securing HelloService
 

--- a/README.adoc
+++ b/README.adoc
@@ -40,12 +40,12 @@ Hello, friend!
 ----
 
 Instead of securing the `HelloService` service by implementing your own authentication service,
-you can allow users to authenticate to the service using social media accounts.
+you can allow users to authenticate the service using social media accounts.
 This will allow you to provide a secure authentication method for your users without having to explicitly implement it.
 
 Open Liberty provides a https://openliberty.io/docs/ref/feature/#socialLogin-1.0.html[Social Media Login feature^]
-that provides configuration elements that allow you to use Facebook, Google, GitHub, or Linkedin for authentication,
-or to configure a custom OAuth2 or OpenID Connect provider.
+that provides configuration elements that allow you to use Facebook, Google, GitHub, or LinkedIn for authentication,
+or to configure a custom OAuth2 or OpenID Connect provider like Amazon.
 
 By the end of this guide, you will be able to secure the HelloService service using three
 social media developer platforms: GitHub, Amazon and Google.
@@ -59,7 +59,7 @@ include::{common-includes}/gitclone.adoc[]
 == Setting up the certificates and truststore
 
 The application you will build in this guide requires certificates for Amazon, Google and GitHub to be added to the truststore.
-You also need to create certificates that your application will provide for HTTPS connections.
+You also need to create a public key certificate that your application will provide for HTTPS connections, and corresponding private key.
 This certificate and private key will need to be added to the keystore for social media login.
 Lastly, you need to create an application on the three social media developer platforms to obtain a client ID and client secret to use their APIs.
 

--- a/README.adoc
+++ b/README.adoc
@@ -300,9 +300,14 @@ In order to obtain OAuth 2.0 credentials for GitHub,
 . Hover over "Sign-in" and click on "Developer Portal".
 . Login into your Amazon account.
 . Click on "Create a New Security Profile".
-. Enter a name and description.
-. Set "Consent Privacy Notice URL" to `\https://localhost.com/privacy`.
-. Click on "Save".
+.. Enter a name and description.
+.. Set "Consent Privacy Notice URL" to `\https://localhost.com/privacy`.
+.. Click on "Save", which will return you to the "Login with Amazon Console".
+. Hover over the "settings" icon under "Manage" and click on "Web Settings".
+. Click on "Edit".
+.. Set `\https://localhost:9443/` as the "Allowed Origins".
+.. Set `\https://localhost:9443/ibm/api/social-login/redirect/amazonLogin` as the "Allowed Return URLs".
+.. Click "Save".
 
 === Setting up for Google
 For your application to communicate securely with Google using HTTPS, the TLS server public key certificates for the following domains need to be added to your application's truststore:

--- a/README.adoc
+++ b/README.adoc
@@ -59,17 +59,17 @@ include::{common-includes}/gitclone.adoc[]
 == Setting up the certificates and truststore
 
 The application you will build in this guide requires certificates for Amazon, Google and GitHub to be added to the truststore.
-You also need to create a public key certificate that your application will provide for HTTPS connections, and corresponding private key.
+You also need to create a server certificate that your application will provide for HTTPS connections, and corresponding private key to decrypt the incoming secure data.
 This certificate and private key will need to be added to the keystore for social media login.
 Lastly, you need to create an application on the three social media developer platforms to obtain a client ID and client secret to use their APIs.
 
 First, navigate to the `start/src/main/liberty/config/resources/security` directory.
 
 === Generating a self signed certificate
-Your application requires a TLS server certificate to securely communicate using HTTPS. In this section, you will
+Your application requires a TLS server certificate and corresponding private key to securely communicate using HTTPS. In this section, you will
 generate a self signed certificate and add it to your application's keystore.
 
-To generate certificates for your service to use for HTTPS connections, run the following command:
+To generate a server certificate and private key for your service to use for HTTPS connections, run the following command:
 include::{common-includes}/os-tabs.adoc[]
 [.tab_content.linux_section.mac_section]
 --
@@ -247,7 +247,7 @@ The last prerequisite step for GitHub is obtaining client ID and client secret f
 In order to obtain OAuth 2.0 credentials for GitHub,
 
 . Log into https://github.com/[GitHub^].
-. Navigate to https://github.com/settings/developers[OAuth Apps^] and click on "New OAuth App".
+. Navigate to https://github.com/settings/developers[OAuth Apps^] and click on "Register a new application".
 . Enter an application name.
 . Set "Homepage URL" to `\https://localhost:9443/`.
 . Set "Authorization callback URL" to `\https://localhost:9443/ibm/api/social-login/redirect/githubLogin`.

--- a/README.adoc
+++ b/README.adoc
@@ -83,6 +83,9 @@ openssl req \
     -days 365 \
     -subj "/C=CA/CN=localhost"
 ```
+
+When prompted for `PEM pass phrase`, enter a pass phrase for `key.pem`.
+
 --
 [.tab_content.windows_section]
 --
@@ -102,7 +105,8 @@ Before the certificate and private key can be imported into the keystore for you
 include::{common-includes}/os-tabs.adoc[]
 [.tab_content.linux_section.mac_section]
 --
-Combine your key and certificate by running the following command. When prompted, set the password for the exported certificate bundle to `changeit`.
+Combine your key and certificate by running the following command.
+When prompted for `Export Password`, set the password for the exported certificate bundle, `certificate.p12`.
 [role='command']
 ```
 openssl pkcs12 \
@@ -205,14 +209,16 @@ keytool \
     -alias github \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit
+    -storepass changeit \
+    -noprompt
 keytool \
     -import -trustcacerts \
     -file github_api.pem \
     -alias github_api \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit
+    -storepass changeit \
+    -noprompt
 ```
 --
 [.tab_content.windows_section]

--- a/README.adoc
+++ b/README.adoc
@@ -231,14 +231,16 @@ keytool \
     -alias github ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit
+    -storepass changeit ^
+    -noprompt
 %JAVA_HOME%\bin\keytool ^
     -import -trustcacerts ^
     -file github_api.pem ^
     -alias github_api ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit
+    -storepass changeit ^
+    -noprompt
 ```
 --
 
@@ -305,14 +307,16 @@ keytool \
     -alias amazon \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit
+    -storepass changeit \
+    -noprompt
 keytool \
     -import -trustcacerts \
     -file amazon_api.pem \
     -alias amazon_api \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit
+    -storepass changeit \
+    -noprompt
 ```
 --
 [.tab_content.windows_section]
@@ -325,14 +329,16 @@ keytool \
     -alias amazon ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit
+    -storepass changeit ^
+    -nporompt
 %JAVA_HOME%\bin\keytool ^
     -import -trustcacerts ^
     -file amazon_api.pem ^
     -alias amazon_api ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit
+    -storepass changeit ^
+    -noprompt
 ```
 --
 
@@ -345,7 +351,7 @@ In order to obtain OAuth 2.0 credentials for GitHub,
 . Login into your Amazon account.
 . Click on "Create a New Security Profile".
 . Enter a name and description.
-. Set "Consent Privacy Notice URL" to "https://localhost.com/privacy".
+. Set "Consent Privacy Notice URL" to `\https://localhost.com/privacy`.
 . Click on "Save".
 
 === Setting up for Google
@@ -399,14 +405,16 @@ keytool \
     -alias google \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit
+    -storepass changeit \
+    -noprompt
 keytool \
     -import -trustcacerts \
     -file googleapis.pem \
     -alias googleapis \
     -keystore slts.p12 \
     -storetype PKCS12 \
-    -storepass changeit
+    -storepass changeit \
+    -noprompt
 ```
 --
 [.tab_content.windows_section]
@@ -419,14 +427,16 @@ keytool \
     -alias google ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit
+    -storepass changeit ^
+    -noprompt
  %JAVA_HOME%\bin\keytool ^
     -import -trustcacerts ^
     -file googleapis.pem ^
     -alias googleapis ^
     -keystore slts.p12 ^
     -storetype PKCS12 ^
-    -storepass changeit
+    -storepass changeit ^
+    -noprompt
 ```
 --
 
@@ -474,7 +484,7 @@ in the `users` role.
 
 The `return "Hello, friend!";` is replaced to output user information.
 The [hotspot=httpServletRequestContext]`HttpServletRequest` context, which is injected using the
-[hotspot=contextAnnotation]`@Context` annotation, allows you to get information about the logged in user
+[hotspot=contextAnnotation]`@Context` annotation, allows you to get information about the logged-in user
 using [hotspot=userPrincipal]`request.getUserPrincipal()`.
 
 HelloService.java 

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -39,45 +39,6 @@
             <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>
-            <version>3.2</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-        <!-- For tests -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.5.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-client</artifactId>
-            <version>3.3.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-extension-providers</artifactId>
-            <version>3.3.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <version>1.0.5</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/finish/src/main/java/io/openliberty/guides/sociallogin/HelloService.java
+++ b/finish/src/main/java/io/openliberty/guides/sociallogin/HelloService.java
@@ -20,26 +20,17 @@ import javax.ws.rs.core.MediaType;
 // tag::rolesAllowedImport[]
 import javax.annotation.security.RolesAllowed;
 // end::rolesAllowedImport[]
-// tag::httpServletRequestContextImport[]
-// tag::httpServletRequestImport[]
-import javax.servlet.http.HttpServletRequest;
-// end::httpServletRequestImport[]
+// tag::securityContextImport[]
+import javax.ws.rs.core.SecurityContext;
+// end::securityContextImport[]
 // tag::contextImport[]
 import javax.ws.rs.core.Context;
 // end::contextImport[]
-// end::httpServletRequestContextImport[]
 // end::newImports[]
 
 @Path("hello")
 // tag::helloService[]
 public class HelloService {
-
-    // tag::httpServletRequestContext[]
-    // tag::contextAnnotation[]
-    @Context
-    // end::contextAnnotation[]
-    HttpServletRequest request;
-    // end::httpServletRequestContext[]
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
@@ -47,11 +38,10 @@ public class HelloService {
     @RolesAllowed({"users"})
     // end::rolesAllowed[]
     // tag::userPrincipal[]
-    public String greet() {
-        if (request.getUserPrincipal() == null) return "Hello, friend!";
-        return "Hello, "
-        		+ request.getUserPrincipal().getName() 
-        		+ '\n' + request.getUserPrincipal().toString();
+    public String greet( // tag::securityContext[]
+            @Context SecurityContext securityContext // end::securityContext[]
+    ) {
+        return "Hello, " + securityContext.getUserPrincipal().getName();
     }
     // end::userPrincipal[]
 }

--- a/finish/src/main/java/io/openliberty/guides/sociallogin/HelloService.java
+++ b/finish/src/main/java/io/openliberty/guides/sociallogin/HelloService.java
@@ -38,8 +38,10 @@ public class HelloService {
     @RolesAllowed({"users"})
     // end::rolesAllowed[]
     // tag::userPrincipal[]
-    public String greet( // tag::securityContext[]
-            @Context SecurityContext securityContext // end::securityContext[]
+    public String greet( 
+        // tag::securityContext[]
+        @Context SecurityContext securityContext
+        // end::securityContext[]
     ) {
         return "Hello, " + securityContext.getUserPrincipal().getName();
     }

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -19,14 +19,14 @@
     <!-- tag::keystore[] -->
     <keyStore id="defaultKeyStore"
               location="${server.output.dir}/resources/security/key.p12"
-              password="changeit"
+              password="[keystore-password]"
               type="PKCS12" />
     <!-- end::keystore[] -->
 
     <!-- tag::truststore[] -->
     <keyStore id="socialLoginKeyStore"
               location="${server.output.dir}/resources/security/slts.p12"
-              password="changeit"
+              password="[truststore-password]"
               type="PKCS12" />
     <!-- end::truststore[] -->
 


### PR DESCRIPTION
Addresses #16 #17 #18
Updated on: http://lgdev1.fyre.ibm.com:4020/guides/social-login.html

## What you'll learn
- [x] ... you can allow users to authenticate __the__ service using social media accounts

- [x] `Linkedin` should be `LinkedIn`

- [x] Mentions that LinkedIn is one of the social media dev platforms that can be used for authentication, though only three social media developer platforms are discussed (GitHub, Amazon and Google).

- [x] `Twitter` is also one of the social media dev platforms. 

- Perhaps it would be worth discussing authentication and configuration for LinkedIn and Twitter; if the social media login feature is finite to those five platforms, it would be worth discussing, whereas if there are many social media platforms that can be used for authentication, those three would suffice as good examples to the common developer. 

  - In either case, the guide could be expressed more swiftly and concise.

  - Should consider trying to "table" or "tab" guide content for each social media developer platform; similar to the os-specific tabs, or if there is other adoc syntax to utilize. 

  <img width="545" alt="image" src="https://user-images.githubusercontent.com/25497083/76355745-3688e800-62eb-11ea-8c0a-1278dd77158c.png">

* [x] Should include `Amazon` in the first paragraph.
![image](https://user-images.githubusercontent.com/26514093/76351669-3c2eff80-62e4-11ea-922b-9ccedbc7b5f7.png)


## Getting Started
## Setting up the certificates and truststore
<img width="551" alt="image" src="https://user-images.githubusercontent.com/25497083/76355808-53bdb680-62eb-11ea-82d8-390298f93700.png">

  - [x] should mention that the private key is also something that is generated [4096 bit RSA private key].

  - [x] would be good to provide an example of output(s). 

### Generating a self signed Certificate
- [x] in the first command i am prompted to `Enter PEM pass phrase`

- [x] "https://localhost.com/privacy" should be with backticks -> `https://localhost.com/privacy`
    > Set "Consent Privacy Notice URL" to "https://localhost.com/privacy".

- [x] `To generate certificates for your service to use for HTTPS connections, ...`
The command prompts the user for a password, might want to add that to the guide, similar to the next paragraph `When prompted, set the password...`
`Before the certificate and private key can be imported into the keystore for your service, ...` 
* [x] The guide asked us to generate a certificate, where did the key come from? Might need some clarification.
  ```
  keytool \
      -importkeystore \
      -srckeystore certificate.p12 \
      -srcstoretype PKCS12 \
      -destkeystore key.p12 \
      -deststoretype PKCS12
  ```
* [x] It prompts us for multiple passwords, clarify if it's asking to set a password or to use a password we set previously
### Setting up for GitHub

![image](https://user-images.githubusercontent.com/26514093/76352665-d0e62d00-62e5-11ea-9804-505baee44ab2.png)

* [x] Button says "Register a new application" not "New OAuth App"
### Setting up for [provider]
```
keytool \
    -import -trustcacerts \
    -file github.pem \
    -alias github \
    -keystore slts.p12 \
    -storetype PKCS12 \
    -storepass changeit
keytool \
    -import -trustcacerts \
    -file github_api.pem \
    -alias github_api \
    -keystore slts.p12 \
    -storetype PKCS12 \
    -storepass changeit
```
* [x] Terminal prompt `Trust this certificate? [no]:` add in the guide that it will prompt you, and to respond with `y`.
## Securing HelloService
- [x] change "logged in" to "logged-in". Change "using `request.getUserPrincipal()`" to "using the `request.getUserPrincipal()` method"
    > allows you to get information about the logged in user using `request.getUserPrincipal()`.
### Configuring the security roles
- [x] hotspot for `HelloService` not highlighting anything 
* [x] The `HelloService` hotspot isn't working
### Adding required features
<img width="514" alt="image" src="https://user-images.githubusercontent.com/25497083/76355854-633cff80-62eb-11ea-93cc-5965cadd1bde.png">

- [x] `src/main/liberty/config/server.xml` doesn't have to be a hotspot as the other hotspots already reference the file 
 
### Adding keystore and truststore
- [x] `src/liberty` should be `src/main/liberty`?
    > Files in the `src/liberty` folder are copied...
### Adding GitHub login configuration
* [x] Add an action block to specify that the user needs to replace the values of certain keys to keep it consistent throughout guides
### Adding Amazon login configuration
* [x] Add an action block to specify that the user needs to replace the values of certain keys to keep it consistent throughout guides
### Adding Google login configuration
* [x] Add an action block to specify that the user needs to replace the values of certain keys to keep it consistent throughout guides
## Running the application
* [x] The `http` link doesn't work in Chrome. Throws an `Your connection is not private NET::ERR_CERT_INVALID` error. I assume it needs to be a `https` link since the rest of the links are `https`
* [x] Getting errors when trying to access the app. 
  ```
  [INFO] [ERROR   ] CWWKS5461E: The social login feature encountered an error while getting user information from the user API [https://api.github.com/user/emails] that is configured for social login configuration [githubLogin]. CWWKS5490E: Cannot process the response from the [https://api.github.com/user/emails] user API endpoint. The response status was [401], error was [{"message":"Requires authentication","documentation_url":"https://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user"}] and the error description was [null].
  [INFO] [ERROR   ] CWWKS5452E: The social login feature cannot authenticate the user because the response from the user API that is configured for the social login configuration [githubLogin] is null or empty.
  ```
## Other
- [x] On Linux, with the steps provided none of the endpoints for `https://localhost:9080/api/hello` are working

* [x] `:page-tags:` includes `Social Media Login` which isn't a tag, see [here](https://github.com/OpenLiberty/openliberty.io/blob/master/src/main/content/_includes/visible-tags.liquid)

* [x] SEO description `Liberty using the SocialLogin feature` should be `Social Media Login`